### PR TITLE
Update Repositories.txt

### DIFF
--- a/Updates/Repositories.txt
+++ b/Updates/Repositories.txt
@@ -29,6 +29,7 @@ Developers
 
 Contributors
 ------------
+<repo>https://github.com/blackyy/LeagueSharp</repo>
 <repo>https://github.com/brian0305/MasterSeries</repo>
 <repo>https://github.com/FlapperDoodlez/LeagueSharp</repo>
 <repo>https://github.com/fueledbyflux/LeagueSharp-Public</repo>
@@ -44,16 +45,15 @@ Contributors
 
 Known Users
 -----------
-<repo>https://github.com/pean153/LeagueSharp</repo>
-<repo>https://github.com/soulcaliber/LeagueSharp</repo>
 <repo>https://github.com/alrik94/LeagueSharp</repo>
-<repo>https://github.com/blackyy/LeagueSharp</repo>
 <repo>https://github.com/Crisdmc/LeagueSharp</repo>
 <repo>https://github.com/DarkAzazel/LeagueSharp</repo>
 <repo>https://github.com/ikkeflikkeri/LeagueSharp</repo>
 <repo>https://github.com/jasteph/LeagueSharp</repo>
 <repo>https://github.com/LittleRedEye/LeagueSharp</repo>
 <repo>https://github.com/TheKushStyle/LeagueSharp</repo>
+<repo>https://github.com/pean153/LeagueSharp</repo>
+<repo>https://github.com/soulcaliber/LeagueSharp</repo>
 <repo>https://github.com/trus/L-</repo>
 <repo>https://github.com/yol0swag/LeagueSharp</repo> 
 <repo>https://github.com/zUsername/LeagueSharp</repo>

--- a/Updates/Repositories.txt
+++ b/Updates/Repositories.txt
@@ -1,7 +1,6 @@
 Core Extensions
 ---------------
 <repo>https://github.com/LeagueSharp/LeagueSharpCommon</repo>
-<repo>https://github.com/LeagueSharp/LeagueSharp.Network</repo>
 
 Administrators
 --------------
@@ -45,6 +44,8 @@ Contributors
 
 Known Users
 -----------
+<repo>https://github.com/pean153/LeagueSharp</repo>
+<repo>https://github.com/soulcaliber/LeagueSharp</repo>
 <repo>https://github.com/alrik94/LeagueSharp</repo>
 <repo>https://github.com/blackyy/LeagueSharp</repo>
 <repo>https://github.com/Crisdmc/LeagueSharp</repo>


### PR DESCRIPTION
add pean152 and soulcaliber, makers of FakeClicks and ezEvade respectively. Removed repo for LeagueSharpNetwork as it is outdated and dead. moved blacky from known users to contributers